### PR TITLE
Add initial Xilinx VCU support for ZCU106

### DIFF
--- a/common/build/vcu_modules.mk
+++ b/common/build/vcu_modules.mk
@@ -1,0 +1,49 @@
+#
+# Copyright (C) 2016 The Android Open-Source Project
+# Copyright (C) 2016 Mentor Graphics Inc.
+# Copyright (C) 2016 Xilinx Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+VCU_MODULES_SRC_DIR := $(ANDROID_BUILD_TOP)/hardware/xilinx/vcu/vcu-modules
+VCU_MODULES_OUT_DIR := $(TARGET_OUT_INTERMEDIATES)/VCU_MODULES_OBJ
+VCU_CROSS_COMP := $(notdir $(TARGET_TOOLS_PREFIX))
+
+VCU_BUILD_FLAGS := \
+	ARCH=$(TARGET_ARCH) \
+	CROSS_COMPILE=$(VCU_CROSS_COMP) \
+	O=$(ANDROID_BUILD_TOP)/$(KERNEL_OUT_DIR) \
+	CFLAGS_MODULE="-fno-pic" \
+	ANDROID_TOOLCHAIN_FLAGS="-mno-android -Werror"
+	
+vcu_modules: install_vcu_modules
+
+$(VCU_MODULES_OUT_DIR): $(VCU_MODULES_SRC_DIR)
+	@$(info Copying directory $(VCU_MODULES_SRC_DIR) to $(VCU_MODULES_OUT_DIR))
+	@rm -rf $(VCU_MODULES_OUT_DIR)
+	@mkdir -p $(VCU_MODULES_OUT_DIR)
+	@cp -rfl $(VCU_MODULES_SRC_DIR)/* $(VCU_MODULES_OUT_DIR)/
+
+build_vcu_modules: build_kernel $(VCU_MODULES_OUT_DIR)
+	KERNEL_SRC=$(KERNEL_SRC_DIR) $(VCU_BUILD_FLAGS) $(MAKE) -C $(VCU_MODULES_OUT_DIR)
+
+install_vcu_modules: build_vcu_modules
+	$(info Copying kernel VCU modules to $(KERNEL_MODULES_OUT))
+	$(hide) mkdir -p $(KERNEL_MODULES_OUT)
+	@cp $(VCU_MODULES_OUT_DIR)/common/allegro.ko $(KERNEL_MODULES_OUT)
+	@cp $(VCU_MODULES_OUT_DIR)/al5d/al5d.ko $(KERNEL_MODULES_OUT)
+	@cp $(VCU_MODULES_OUT_DIR)/al5e/al5e.ko $(KERNEL_MODULES_OUT)
+
+.PHONY: vcu_modules
+droidcore: vcu_modules

--- a/ultrazed-eg/ultrazed_eg_iocc.mk
+++ b/ultrazed-eg/ultrazed_eg_iocc.mk
@@ -32,7 +32,7 @@ PRODUCT_MODEL := AOSP on Avnet UltraZed-EG with IO Carrier Card
 PRODUCT_MANUFACTURER := Avnet
 
 # Specify variables for kernel build
-KERNEL_SRC_DIR ?= linux-xlnx
+KERNEL_SRC_DIR ?= $(ANDROID_BUILD_TOP)/linux-xlnx
 KERNEL_CFG_NAME ?= xilinx_zynqmp_android_defconfig
 KERNEL_DTS_NAMES ?= \
 	zynqmp-ultrazed-eg-iocc.dts

--- a/zcu102/zcu102.mk
+++ b/zcu102/zcu102.mk
@@ -34,7 +34,7 @@ PRODUCT_MODEL := AOSP on ZynqMP ZCU102
 PRODUCT_MANUFACTURER := Xilinx
 
 # Specify variables for kernel build
-KERNEL_SRC_DIR ?= linux-xlnx
+KERNEL_SRC_DIR ?= $(ANDROID_BUILD_TOP)/linux-xlnx
 KERNEL_CFG_NAME ?= xilinx_zynqmp_android_defconfig
 KERNEL_DTS_NAMES ?= \
 	zynqmp-zcu102-rev1.0.dts

--- a/zcu106/AndroidProducts.mk
+++ b/zcu106/AndroidProducts.mk
@@ -15,4 +15,5 @@
 #
 
 PRODUCT_MAKEFILES := \
-	$(LOCAL_DIR)/zcu106.mk
+	$(LOCAL_DIR)/zcu106.mk \
+	$(LOCAL_DIR)/zcu106_vcu.mk

--- a/zcu106/device-common.mk
+++ b/zcu106/device-common.mk
@@ -38,12 +38,6 @@ PRODUCT_COPY_FILES +=  \
     frameworks/native/data/etc/android.hardware.usb.accessory.xml:system/etc/permissions/android.hardware.usb.accessory.xml \
     frameworks/native/data/etc/android.hardware.usb.host.xml:system/etc/permissions/android.hardware.usb.host.xml
 
-# Copy media codec settings
-PRODUCT_COPY_FILES +=  \
-    frameworks/av/media/libstagefright/data/media_codecs_google_audio.xml:system/etc/media_codecs_google_audio.xml \
-    frameworks/av/media/libstagefright/data/media_codecs_google_video.xml:system/etc/media_codecs_google_video.xml \
-    device/xilinx/common/media_codecs.xml:system/etc/media_codecs.xml
-
 # Add libion for graphics
 PRODUCT_PACKAGES += \
 	libion

--- a/zcu106/vendorsetup.sh
+++ b/zcu106/vendorsetup.sh
@@ -14,3 +14,5 @@
 
 add_lunch_combo zcu106-userdebug
 add_lunch_combo zcu106-eng
+add_lunch_combo zcu106_vcu-userdebug
+add_lunch_combo zcu106_vcu-eng

--- a/zcu106/zcu106.mk
+++ b/zcu106/zcu106.mk
@@ -32,7 +32,7 @@ PRODUCT_MODEL := AOSP on Xilinx ZCU106 Board
 PRODUCT_MANUFACTURER := Xilinx
 
 # Specify variables for kernel build
-KERNEL_SRC_DIR ?= linux-xlnx
+KERNEL_SRC_DIR ?= $(ANDROID_BUILD_TOP)/linux-xlnx
 KERNEL_CFG_NAME ?= xilinx_zynqmp_android_defconfig
 KERNEL_DTS_NAMES ?= \
 	zynqmp-zcu106-revA.dts

--- a/zcu106/zcu106/device-zcu106.mk
+++ b/zcu106/zcu106/device-zcu106.mk
@@ -25,6 +25,12 @@ PRODUCT_COPY_FILES += \
 PRODUCT_COPY_FILES += \
    $(LOCAL_PATH)/uEnv.txt:boot/uEnv.txt
 
+# Copy media codec settings
+PRODUCT_COPY_FILES +=  \
+    frameworks/av/media/libstagefright/data/media_codecs_google_audio.xml:system/etc/media_codecs_google_audio.xml \
+    frameworks/av/media/libstagefright/data/media_codecs_google_video.xml:system/etc/media_codecs_google_video.xml \
+    device/xilinx/common/media_codecs.xml:system/etc/media_codecs.xml
+
 # Copy prebuilt BOOT.BIN if it exists
 PRODUCT_COPY_FILES += $(call add-to-product-copy-files-if-exists,\
 	$(LOCAL_PATH)/BOOT.BIN:boot/BOOT.BIN)

--- a/zcu106/zcu106_vcu.mk
+++ b/zcu106/zcu106_vcu.mk
@@ -1,0 +1,54 @@
+#
+# Copyright (C) 2018 Mentor Graphics Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Inherit device specific configurations
+$(call inherit-product, device/xilinx/zcu106/device-common.mk)
+$(call inherit-product, device/xilinx/zcu106/zcu106_vcu/device-zcu106_vcu.mk)
+
+# Inherit full base product
+$(call inherit-product, $(SRC_TARGET_DIR)/product/full_base.mk)
+
+# Include vendor binaries
+$(call inherit-product-if-exists, vendor/xilinx/zynqmp/device-vendor.mk)
+
+# Specify product details
+PRODUCT_NAME := zcu106_vcu
+PRODUCT_DEVICE := zcu106_vcu
+PRODUCT_BRAND := Android
+PRODUCT_MODEL := AOSP on Xilinx ZCU106 Board with VCU support
+PRODUCT_MANUFACTURER := Xilinx
+
+# Specify variables for kernel build
+KERNEL_SRC_DIR ?= $(ANDROID_BUILD_TOP)/linux-xlnx
+KERNEL_CFG_NAME ?= xilinx_zynqmp_vcu_android_defconfig
+KERNEL_DTS_NAMES ?= \
+	zynqmp-zcu106-revA-vcu.dts
+
+# Check for availability of kernel source
+ifneq ($(wildcard $(KERNEL_SRC_DIR)/Makefile),)
+	# Give precedence to TARGET_PREBUILT_KERNEL
+	ifeq ($(TARGET_PREBUILT_KERNEL),)
+		TARGET_KERNEL_BUILT_FROM_SOURCE := true
+	endif
+endif
+
+# Include gralloc for Mali GPU
+PRODUCT_PACKAGES += \
+	gralloc.zynqmp
+
+UBOOT_SRC_DIR ?= bootable/u-boot-xlnx
+UBOOT_CFG_NAME ?= xilinx_zynqmp_zcu106_revA_defconfig
+TARGET_UBOOT_BUILT_FROM_SOURCE := true

--- a/zcu106/zcu106_vcu/AndroidBoard.mk
+++ b/zcu106/zcu106_vcu/AndroidBoard.mk
@@ -1,0 +1,30 @@
+#
+# Copyright (C) 2017 Mentor Graphics Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# include makefile for Xilinx kernel
+# variables for kernel build should be set in
+# product makefile
+include device/xilinx/common/build/kernel.mk
+
+# include makefile for Xilinx VCU kernel modules
+# it should be after kernel.mk since it uses some
+# kernel build variables
+include device/xilinx/common/build/vcu_modules.mk
+
+# include makefile for Xilinx U-Boot
+# variables for U-Boot build should be set in
+# product makefile
+include device/xilinx/common/build/u-boot.mk

--- a/zcu106/zcu106_vcu/BoardConfig.mk
+++ b/zcu106/zcu106_vcu/BoardConfig.mk
@@ -1,0 +1,20 @@
+#
+# Copyright (C) 2017 Mentor Graphics Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+include device/xilinx/zcu106/BoardConfigCommon.mk
+
+# Enable Xilinx VCU multimedia stack
+TARGET_USES_XILINX_VCU := true
+

--- a/zcu106/zcu106_vcu/device-zcu106_vcu.mk
+++ b/zcu106/zcu106_vcu/device-zcu106_vcu.mk
@@ -30,6 +30,8 @@ PRODUCT_COPY_FILES += \
 
 # Copy media_codec config
 PRODUCT_COPY_FILES += \
+    frameworks/av/media/libstagefright/data/media_codecs_google_audio.xml:system/etc/media_codecs_google_audio.xml \
+    frameworks/av/media/libstagefright/data/media_codecs_google_video.xml:system/etc/media_codecs_google_video.xml \
     device/xilinx/zcu106/zcu106_vcu/media_codecs.xml:system/etc/media_codecs.xml
 
 # Copy bootloader envs

--- a/zcu106/zcu106_vcu/device-zcu106_vcu.mk
+++ b/zcu106/zcu106_vcu/device-zcu106_vcu.mk
@@ -1,0 +1,62 @@
+#
+# Copyright (C) 2017 Mentor Graphics Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Copy basic config files
+PRODUCT_COPY_FILES += \
+    device/xilinx/zcu106/fstab.common:root/fstab.zcu106 \
+    device/xilinx/zcu106/init.common.rc:root/init.zcu106.rc \
+    device/xilinx/zcu106/init.common.usb.rc:root/init.zcu106.usb.rc \
+    device/xilinx/zcu106/ueventd.common.rc:root/ueventd.zcu106.rc
+
+# Copy VCU firmware
+PRODUCT_COPY_FILES += \
+    hardware/xilinx/vcu/vcu-firmware/1.0.0/lib/firmware/al5d.fw:system/etc/firmware/al5d.fw \
+    hardware/xilinx/vcu/vcu-firmware/1.0.0/lib/firmware/al5d_b.fw:system/etc/firmware/al5d_b.fw \
+    hardware/xilinx/vcu/vcu-firmware/1.0.0/lib/firmware/al5e.fw:system/etc/firmware/al5e.fw \
+    hardware/xilinx/vcu/vcu-firmware/1.0.0/lib/firmware/al5e_b.fw:system/etc/firmware/al5e_b.fw
+
+# Copy media_codec config
+PRODUCT_COPY_FILES += \
+    device/xilinx/zcu106/zcu106_vcu/media_codecs.xml:system/etc/media_codecs.xml
+
+# Copy bootloader envs
+PRODUCT_COPY_FILES += \
+   $(LOCAL_PATH)/uEnv.txt:boot/uEnv.txt
+
+# Copy prebuilt BOOT.BIN if it exists
+PRODUCT_COPY_FILES += $(call add-to-product-copy-files-if-exists,\
+    $(LOCAL_PATH)/BOOT.BIN:boot/BOOT.BIN)
+
+# Copy FPGA firmware if it exists
+PRODUCT_COPY_FILES += $(call add-to-product-copy-files-if-exists,\
+    $(LOCAL_PATH)/bitstream.bit:boot/bitstream.bit)
+
+# Include packages for VCU
+PRODUCT_PACKAGES += \
+    liballegro_decode \
+    liballegro_encode \
+    al_decoder \
+    al_encoder \
+    libOMX.allegro.core \
+    libOMX.allegro.video_decoder \
+    libOMX.allegro.video_encoder \
+    omx_decoder \
+    omx_encoder \
+    libstagefrighthw
+
+# Install required kernel modules
+KERNEL_MODULES += \
+    drivers/misc/xlnx_vcu.ko

--- a/zcu106/zcu106_vcu/device-zcu106_vcu.mk
+++ b/zcu106/zcu106_vcu/device-zcu106_vcu.mk
@@ -17,9 +17,9 @@
 # Copy basic config files
 PRODUCT_COPY_FILES += \
     device/xilinx/zcu106/fstab.common:root/fstab.zcu106 \
-    device/xilinx/zcu106/init.common.rc:root/init.zcu106.rc \
+    device/xilinx/zcu106/zcu106_vcu/init.zcu106_vcu.rc:root/init.zcu106.rc \
     device/xilinx/zcu106/init.common.usb.rc:root/init.zcu106.usb.rc \
-    device/xilinx/zcu106/ueventd.common.rc:root/ueventd.zcu106.rc
+    device/xilinx/zcu106/zcu106_vcu/ueventd.zcu106_vcu.rc:root/ueventd.zcu106.rc
 
 # Copy VCU firmware
 PRODUCT_COPY_FILES += \

--- a/zcu106/zcu106_vcu/init.zcu106_vcu.rc
+++ b/zcu106/zcu106_vcu/init.zcu106_vcu.rc
@@ -1,0 +1,54 @@
+import init.${ro.hardware}.usb.rc
+
+on init
+    # mount debugfs
+    mount debugfs /sys/kernel/debug /sys/kernel/debug
+
+on fs
+    mount_all /fstab.zcu106
+    setprop ro.crypto.fuse_sdcard false
+
+on post-fs-data
+    mkdir /data/media 0770 media_rw media_rw
+
+on post-fs
+    # For legacy support
+    # See storage config details at http://source.android.com/tech/storage/
+    # since /storage is mounted on post-fs in init.rc
+    symlink /sdcard /storage/sdcard0
+
+    # fake some battery state
+    setprop status.battery.state Slow
+    setprop status.battery.level 5
+    setprop status.battery.level_raw  50
+    setprop status.battery.level_scale 9
+
+    # Set supported opengles version - OpenGLES 2
+    setprop ro.opengles.version 131072
+    
+    # Initialize VCU
+    insmod /system/vendor/modules/allegro.ko
+    insmod /system/vendor/modules/al5e.ko
+    insmod /system/vendor/modules/al5d.ko
+    insmod /system/vendor/modules/xlnx_vcu.ko
+
+on property:sys.boot_completed=1
+    # update cpuset now that processors are up
+    # Foreground should contain all cores
+    write /dev/cpuset/foreground/cpus 0-3
+
+    # top-app gets all cpus
+    write /dev/cpuset/top-app/cpus 0-3
+
+    # Add foreground/boost cpuset, it is used for app launches,
+    # and maybe other high priority tasks in the future.
+    # It's to be set to whatever cores should be used
+    # for short term high-priority tasks.
+    write /dev/cpuset/foreground/boost/cpus 0-3
+
+    # background contains a small subset (generally one core)
+    write /dev/cpuset/background/cpus 0
+
+    # limit system background services to use 2 cores
+    write /dev/cpuset/system-background/cpus 0-1
+

--- a/zcu106/zcu106_vcu/media_codecs.xml
+++ b/zcu106/zcu106_vcu/media_codecs.xml
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright (C) 2012 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<!--
+<!DOCTYPE MediaCodecs [
+<!ELEMENT Include EMPTY>
+<!ATTLIST Include href CDATA #REQUIRED>
+<!ELEMENT MediaCodecs (Decoders|Encoders|Include)*>
+<!ELEMENT Decoders (MediaCodec|Include)*>
+<!ELEMENT Encoders (MediaCodec|Include)*>
+<!ELEMENT MediaCodec (Type|Quirk|Include)*>
+<!ATTLIST MediaCodec name CDATA #REQUIRED>
+<!ATTLIST MediaCodec type CDATA>
+<!ELEMENT Type EMPTY>
+<!ATTLIST Type name CDATA #REQUIRED>
+<!ELEMENT Quirk EMPTY>
+<!ATTLIST Quirk name CDATA #REQUIRED>
+]>
+
+There's a simple and a complex syntax to declare the availability of a
+media codec:
+
+A codec that properly follows the OpenMax spec and therefore doesn't have any
+quirks and that only supports a single content type can be declared like so:
+
+    <MediaCodec name="OMX.foo.bar" type="something/interesting" />
+
+If a codec has quirks OR supports multiple content types, the following syntax
+can be used:
+
+    <MediaCodec name="OMX.foo.bar" >
+        <Type name="something/interesting" />
+        <Type name="something/else" />
+        ...
+        <Quirk name="requires-allocate-on-input-ports" />
+        <Quirk name="requires-allocate-on-output-ports" />
+        <Quirk name="output-buffers-are-unreadable" />
+    </MediaCodec>
+
+Only the three quirks included above are recognized at this point:
+
+"requires-allocate-on-input-ports"
+    must be advertised if the component does not properly support specification
+    of input buffers using the OMX_UseBuffer(...) API but instead requires
+    OMX_AllocateBuffer to be used.
+
+"requires-allocate-on-output-ports"
+    must be advertised if the component does not properly support specification
+    of output buffers using the OMX_UseBuffer(...) API but instead requires
+    OMX_AllocateBuffer to be used.
+
+"output-buffers-are-unreadable"
+    must be advertised if the emitted output buffers of a decoder component
+    are not readable, i.e. use a custom format even though abusing one of
+    the official OMX colorspace constants.
+    Clients of such decoders will not be able to access the decoded data,
+    naturally making the component much less useful. The only use for
+    a component with this quirk is to render the output to the screen.
+    Audio decoders MUST NOT advertise this quirk.
+    Video decoders that advertise this quirk must be accompanied by a
+    corresponding color space converter for thumbnail extraction,
+    matching surfaceflinger support that can render the custom format to
+    a texture and possibly other code, so just DON'T USE THIS QUIRK.
+
+-->
+
+<MediaCodecs>
+    <Include href="media_codecs_google_audio.xml" />
+    <Decoders>
+        <MediaCodec name="OMX.allegro.h264.decoder" type="video/avc" >
+            <Limit name="size" min="32x32" max="3840x2176" />
+            <Limit name="alignment" value="2x2" />
+            <Limit name="block-size" value="16x16" />
+            <Limit name="blocks-per-second" min="1" max="783360" />
+            <Limit name="bitrate" range="1-62500000" />
+            <Feature name="adaptive-playback" optional="yes"/>
+        </MediaCodec>
+
+        <MediaCodec name="OMX.allegro.h265.decoder" type="video/hevc" >
+            <Limit name="size" min="180x180" max="3840x2176" />
+            <Limit name="alignment" value="2x2" />
+            <Limit name="block-size" value="16x16" />
+            <Limit name="blocks-per-second" min="1" max="2000000" />
+            <Limit name="bitrate" range="1-120000000" />
+        </MediaCodec>
+    </Decoders>
+
+    <Encoders>
+        <MediaCodec name="OMX.allegro.h264.encoder" type="video/avc" >
+            <Limit name="size" min="48x48" max="3840x2176" />
+            <Limit name="alignment" value="2x2" />
+            <Limit name="block-size" value="16x16" />
+            <Limit name="blocks-per-second" min="1" max="783360" />
+            <Limit name="bitrate" range="1-50000000" />
+        </MediaCodec>
+
+        <MediaCodec name="OMX.allegro.h265.encoder" type="video/hevc" >
+            <Limit name="size" min="180x180" max="3840x2176" />
+            <Limit name="alignment" value="2x2" />
+            <Limit name="block-size" value="16x16" />
+            <Limit name="blocks-per-second" min="1" max="2000000" />
+            <Limit name="bitrate" range="1-120000000" />
+        </MediaCodec>
+    </Encoders>
+    <Include href="media_codecs_google_video.xml" />
+</MediaCodecs>

--- a/zcu106/zcu106_vcu/uEnv.txt
+++ b/zcu106/zcu106_vcu/uEnv.txt
@@ -1,0 +1,7 @@
+bootargs=init=/init video=DP-1:1920x1080 androidboot.selinux=permissive androidboot.hardware=zcu106 console=ttyPS0,115200 firmware_class.path=/system/etc/firmware cma=1500M clk_ignore_unused uio_pdrv_genirq.of_id=generic-uio"
+dtb_name=zynqmp-zcu106-revA-vcu.dtb
+uramdisk_addr=0x10000000
+load_kernel=load mmc $sdbootdev:$partid $kernel_addr Image
+load_dtb=load mmc $sdbootdev:$partid $fdt_addr $dtb_name
+load_uramdisk=load mmc $sdbootdev:$partid $uramdisk_addr uramdisk.img
+uenvcmd=run load_uramdisk && run load_kernel && run load_dtb && booti $kernel_addr $uramdisk_addr $fdt_addr

--- a/zcu106/zcu106_vcu/ueventd.zcu106_vcu.rc
+++ b/zcu106/zcu106_vcu/ueventd.zcu106_vcu.rc
@@ -1,0 +1,9 @@
+#
+/dev/ttyS*                0666   system     system
+/proc                     0666   system     system
+/dev/mali                 0666   system     graphics
+/dev/ion                  0666   system     graphics
+/dev/graphics/fb0         0666   system     graphics
+/dev/rfkill               0666   wifi       system
+/dev/allegroIP            0666   media      mediacodec
+/dev/allegroDecodeIP      0666   media      mediacodec


### PR DESCRIPTION
* Add zcu106_vcu build target. It builds and installs VCU related drivers, libs and firmware additionally to basic ZCU106 BSP
* VCU OMX IL integration is a work in progress at the moment and media playback/capture is not functional. This PR mostly adds infrastructure to build and install all required components