### PR TITLE
Add ZCU102 support for Android 8

### DIFF
--- a/zcu102/AndroidProducts.mk
+++ b/zcu102/AndroidProducts.mk
@@ -16,5 +16,5 @@
 # limitations under the License.
 #
 
-# PRODUCT_MAKEFILES := \
-# 	$(LOCAL_DIR)/zcu102.mk
+PRODUCT_MAKEFILES := \
+	$(LOCAL_DIR)/zcu102.mk

--- a/zcu102/BoardConfigCommon.mk
+++ b/zcu102/BoardConfigCommon.mk
@@ -57,6 +57,9 @@ TARGET_USERIMAGES_SPARSE_EXT_DISABLED := true
 BOARD_SEPOLICY_DIRS := device/xilinx/common/sepolicy
 BOARD_SEPOLICY_DIRS += device/xilinx/zcu102/sepolicy
 
+DEVICE_MANIFEST_FILE := device/xilinx/zcu102/manifest.xml
+DEVICE_MATRIX_FILE := device/xilinx/zcu102/compatibility_matrix.xml
+
 ifeq ($(HOST_OS),linux)
     ifeq ($(WITH_DEXPREOPT),)
       WITH_DEXPREOPT := true

--- a/zcu102/compatibility_matrix.xml
+++ b/zcu102/compatibility_matrix.xml
@@ -1,0 +1,86 @@
+<manifest version="1.0" type="device">
+    <hal format="hidl">
+        <name>android.hardware.audio</name>
+        <transport arch="32+64">passthrough</transport>
+        <version>2.0</version>
+        <interface>
+            <name>IDevicesFactory</name>
+            <instance>default</instance>
+        </interface>
+    </hal>
+    <hal format="hidl">
+        <name>android.hardware.audio.effect</name>
+        <transport arch="32+64">passthrough</transport>
+        <version>2.0</version>
+        <interface>
+            <name>IEffectsFactory</name>
+            <instance>default</instance>
+        </interface>
+    </hal>
+    <hal format="hidl">
+        <name>android.hardware.cas</name>
+        <transport>hwbinder</transport>
+        <version>1.0</version>
+        <interface>
+            <name>IMediaCasService</name>
+            <instance>default</instance>
+        </interface>
+    </hal>
+    <hal format="hidl">
+        <name>android.hardware.configstore</name>
+        <transport>hwbinder</transport>
+        <version>1.0</version>
+        <interface>
+            <name>ISurfaceFlingerConfigs</name>
+            <instance>default</instance>
+        </interface>
+    </hal>
+    <hal format="hidl">
+        <name>android.hardware.graphics.allocator</name>
+        <transport arch="32+64">passthrough</transport>
+        <version>2.0</version>
+        <interface>
+            <name>IAllocator</name>
+            <instance>default</instance>
+        </interface>
+    </hal>
+    <hal format="hidl">
+        <name>android.hardware.graphics.mapper</name>
+        <transport arch="32+64">passthrough</transport>
+        <version>2.0</version>
+        <interface>
+            <name>IMapper</name>
+            <instance>default</instance>
+        </interface>
+    </hal>
+    <hal format="hidl">
+        <name>android.hardware.keymaster</name>
+        <transport arch="32+64">passthrough</transport>
+        <version>3.0</version>
+        <interface>
+            <name>IKeymasterDevice</name>
+            <instance>default</instance>
+        </interface>
+    </hal>
+    <hal format="hidl">
+        <name>android.hardware.media.omx</name>
+        <transport>hwbinder</transport>
+        <version>1.0</version>
+        <interface>
+            <name>IOmx</name>
+            <instance>default</instance>
+        </interface>
+        <interface>
+            <name>IOmxStore</name>
+            <instance>default</instance>
+        </interface>
+    </hal>
+    <hal format="hidl">
+        <name>android.hardware.tests.libhwbinder</name>
+        <transport arch="32+64">passthrough</transport>
+        <version>1.0</version>
+    </hal>
+    <sepolicy>
+        <version>0.0</version>
+    </sepolicy>
+</manifest>

--- a/zcu102/device-common.mk
+++ b/zcu102/device-common.mk
@@ -40,15 +40,29 @@ PRODUCT_COPY_FILES +=  \
     frameworks/native/data/etc/android.hardware.usb.accessory.xml:system/etc/permissions/android.hardware.usb.accessory.xml \
     frameworks/native/data/etc/android.hardware.usb.host.xml:system/etc/permissions/android.hardware.usb.host.xml
 
-# Copy media codec settings
-PRODUCT_COPY_FILES +=  \
-    frameworks/av/media/libstagefright/data/media_codecs_google_audio.xml:system/etc/media_codecs_google_audio.xml \
-    frameworks/av/media/libstagefright/data/media_codecs_google_video.xml:system/etc/media_codecs_google_video.xml \
-    device/xilinx/common/media_codecs.xml:system/etc/media_codecs.xml
-
 # Add libion for graphics
 PRODUCT_PACKAGES += \
-	libion
+	libion \
+	libdrm
 
 # Include libs for SW graphics
 PRODUCT_PACKAGES += libGLES_android
+
+# Graphics HAL
+PRODUCT_PACKAGES += \
+    android.hardware.graphics.allocator@2.0-impl \
+    android.hardware.graphics.mapper@2.0-impl \
+    android.hardware.graphics.composer@2.1-impl \
+
+PRODUCT_PACKAGES += \
+    android.hardware.audio@2.0-impl \
+	android.hardware.audio.effect@2.0-impl \
+
+# Keymaster HAL
+PRODUCT_PACKAGES += \
+    android.hardware.keymaster@3.0-impl
+
+TARGET_USES_HWC2 := true
+BOARD_USES_DRM_HWCOMPOSER := true
+PRODUCT_PACKAGES += hwcomposer.drm
+SF_START_GRAPHICS_ALLOCATOR_SERVICE := true

--- a/zcu102/init.common.rc
+++ b/zcu102/init.common.rc
@@ -2,7 +2,7 @@ import init.${ro.hardware}.usb.rc
 
 on init
     # mount debugfs
-    mount debugfs /sys/kernel/debug /sys/kernel/debug
+    mount debugfs /sys/kernel/debug /sys/kernel/debug mode=755
 
 on fs
     mount_all /fstab.zcu102
@@ -25,6 +25,17 @@ on post-fs
 
     # Set supported opengles version - OpenGLES 2
     setprop ro.opengles.version 131072
+
+    # Set Display density
+    setprop ro.sf.lcd_density 160
+
+    # Configure hwcomposer
+    setprop ro.hardware.hwcomposer drm
+    setprop hwc.drm.use_framebuffer_target 1
+    setprop hwc.drm.use_overlay_planes 0
+
+    chown graphics graphics /sys/kernel/debug/sync/sw_sync
+    chmod 777 /sys/kernel/debug/sync/sw_sync
 
 on property:sys.boot_completed=1
     # update cpuset now that processors are up

--- a/zcu102/manifest.xml
+++ b/zcu102/manifest.xml
@@ -1,0 +1,108 @@
+<!-- 
+    This is a skeleton device manifest. Notes: 
+    1. android.hidl.*, android.frameworks.*, android.system.* are not included.
+    2. If a HAL is supported in both hwbinder and passthrough transport, 
+       only hwbinder is shown.
+    3. It is likely that HALs in passthrough transport does not have
+       <interface> declared; users will have to write them by hand.
+    4. A HAL with lower minor version can be overridden by a HAL with
+       higher minor version if they have the same name and major version.
+    5. sepolicy version is set to 0.0. It is recommended that the entry
+       is removed from the manifest file and written by assemble_vintf
+       at build time.
+-->
+<manifest version="1.0" type="device">
+    <hal format="hidl">
+        <name>android.hardware.audio</name>
+        <transport arch="32+64">passthrough</transport>
+        <version>2.0</version>
+        <interface>
+            <name>IDevicesFactory</name>
+            <instance>default</instance>
+        </interface>
+    </hal>
+    <hal format="hidl">
+        <name>android.hardware.audio.effect</name>
+        <transport arch="32+64">passthrough</transport>
+        <version>2.0</version>
+        <interface>
+            <name>IEffectsFactory</name>
+            <instance>default</instance>
+        </interface>
+    </hal>
+    <hal format="hidl">
+        <name>android.hardware.cas</name>
+        <transport>hwbinder</transport>
+        <version>1.0</version>
+        <interface>
+            <name>IMediaCasService</name>
+            <instance>default</instance>
+        </interface>
+    </hal>
+    <hal format="hidl">
+        <name>android.hardware.configstore</name>
+        <transport>hwbinder</transport>
+        <version>1.0</version>
+        <interface>
+            <name>ISurfaceFlingerConfigs</name>
+            <instance>default</instance>
+        </interface>
+    </hal>
+    <hal format="hidl">
+        <name>android.hardware.graphics.allocator</name>
+        <transport arch="32+64">passthrough</transport>
+        <version>2.0</version>
+        <interface>
+            <name>IAllocator</name>
+            <instance>default</instance>
+        </interface>
+    </hal>
+    <hal format="hidl">
+        <name>android.hardware.graphics.mapper</name>
+        <transport arch="32+64">passthrough</transport>
+        <version>2.0</version>
+        <interface>
+            <name>IMapper</name>
+            <instance>default</instance>
+        </interface>
+    </hal>
+    <hal format="hidl">
+        <name>android.hardware.keymaster</name>
+        <transport arch="32+64">passthrough</transport>
+        <version>3.0</version>
+        <interface>
+            <name>IKeymasterDevice</name>
+            <instance>default</instance>
+        </interface>
+    </hal>
+    <hal format="hidl">
+        <name>android.hardware.media.omx</name>
+        <transport>hwbinder</transport>
+        <version>1.0</version>
+        <interface>
+            <name>IOmx</name>
+            <instance>default</instance>
+        </interface>
+        <interface>
+            <name>IOmxStore</name>
+            <instance>default</instance>
+        </interface>
+    </hal>
+    <hal format="hidl">
+        <name>android.hardware.graphics.composer</name>
+        <transport arch="32+64">passthrough</transport>
+        <version>2.1</version>
+        <interface>
+            <name>IComposer</name>
+            <instance>default</instance>
+        </interface>
+    </hal>
+    <hal format="hidl">
+        <name>android.hardware.tests.libhwbinder</name>
+        <transport arch="32+64">passthrough</transport>
+        <version>1.0</version>
+    </hal>
+    <sepolicy>
+        <version>0.0</version>
+    </sepolicy>
+</manifest>

--- a/zcu102/ueventd.common.rc
+++ b/zcu102/ueventd.common.rc
@@ -5,3 +5,4 @@
 /dev/ion                  0666   system     graphics
 /dev/graphics/fb0         0666   system     graphics
 /dev/rfkill               0666   wifi       system
+/dev/sw_sync              0666   system     graphics

--- a/zcu102/vendorsetup.sh
+++ b/zcu102/vendorsetup.sh
@@ -13,5 +13,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# add_lunch_combo zcu102-userdebug
-# add_lunch_combo zcu102-eng
+add_lunch_combo zcu102-userdebug
+add_lunch_combo zcu102-eng


### PR DESCRIPTION
    zcu102: Add support for ZCU102 board

    Add support for Android on ZCU102 board.
    Tested on es2 silicon, rev1.0 board.

    Changes are in sync with the support provided for zcu106 board.

    Supported/tested features/peripherals:
    * DisplayPort output
    * Booting from SD card
    * USB keyboard and mouse
    * Ethernet
