### PR TITLE
Upgrade zcu106_vcu target to use Xilinx VCU TRD 2018.3

### DIFF
--- a/common/audio/Android.mk
+++ b/common/audio/Android.mk
@@ -26,6 +26,8 @@ include $(CLEAR_VARS)
 
 LOCAL_MODULE := audio.primary.$(TARGET_BOARD_PLATFORM)
 LOCAL_MODULE_RELATIVE_PATH := hw
+LOCAL_VENDOR_MODULE := true
+
 LOCAL_SRC_FILES := audio_hw.c
 LOCAL_SHARED_LIBRARIES := liblog libcutils libtinyalsa
 LOCAL_CFLAGS := -Wno-unused-parameter

--- a/common/audio/audio_hw.c
+++ b/common/audio/audio_hw.c
@@ -294,7 +294,7 @@ static int out_get_presentation_position(const struct audio_stream_out *stream,
                                    uint64_t *frames, struct timespec *timestamp)
 {
     struct alsa_stream_out *out = (struct alsa_stream_out *)stream;
-    int ret = -1;
+    int ret = -ENODATA;
 
         if (out->pcm) {
             unsigned int avail;

--- a/common/build/hdmi_modules.mk
+++ b/common/build/hdmi_modules.mk
@@ -43,7 +43,6 @@ install_hdmi_modules: build_hdmi_modules
 	@cp $(HDMI_MODULES_OUT_DIR)/hdmi/xilinx-vphy.ko $(KERNEL_MODULES_OUT)
 	@cp $(HDMI_MODULES_OUT_DIR)/hdmi/xilinx-hdmi-tx.ko $(KERNEL_MODULES_OUT)
 	@cp $(HDMI_MODULES_OUT_DIR)/hdmi/xilinx-hdmi-rx.ko $(KERNEL_MODULES_OUT)
-	@cp $(HDMI_MODULES_OUT_DIR)/clk/si5324.ko $(KERNEL_MODULES_OUT)
 	@cp $(HDMI_MODULES_OUT_DIR)/misc/dp159.ko $(KERNEL_MODULES_OUT)
 
 .PHONY: hdmi_modules

--- a/common/camera/v4l2_xilinx_hdmi_wrapper.cpp
+++ b/common/camera/v4l2_xilinx_hdmi_wrapper.cpp
@@ -100,11 +100,11 @@ int V4L2XilinxHdmiWrapper::FindSubdevices() {
   // name of hdmi_rx subdevice
   char rx_device_name[PROPERTY_VALUE_MAX];
 
-  property_get("xlnx.v4l2.hdmi.main_dts_name", hdmi_device_name, "vcap_hdmi_1");
-  property_get("xlnx.v4l2.hdmi.scaler_dts_name", scaler_device_name, "a0080000.scaler");
-  property_get("xlnx.v4l2.hdmi.rx_dts_name", rx_device_name, "a0000000.hdmi_rx_ss");
+  property_get("xlnx.v4l2.hdmi.main_dts_name", hdmi_device_name, "vcap_hdmi");
+  property_get("xlnx.v4l2.hdmi.scaler_dts_name", scaler_device_name, "a0080000.v_proc_ss");
+  property_get("xlnx.v4l2.hdmi.rx_dts_name", rx_device_name, "a0000000.v_hdmi_rx_ss");
 
-  std::string sysfs_path = "/sys/devices/platform/amba/amba:";
+  std::string sysfs_path = "/sys/devices/platform/amba_pl@0/amba_pl@0:";
   sysfs_path += hdmi_device_name;
   sysfs_path += "/video4linux/";
 
@@ -132,7 +132,6 @@ int V4L2XilinxHdmiWrapper::FindSubdevices() {
         int ret = read(fd, tmp_name, PROPERTY_VALUE_MAX);
         if (ret <= 0)
           continue;
-
         if(!found_scaler && (strncmp(scaler_device_name, tmp_name, strlen(scaler_device_name)) == 0)){
           found_scaler = true;
           scaler_dev_path_ = "/dev/";

--- a/common/gralloc/gralloc_module.cpp
+++ b/common/gralloc/gralloc_module.cpp
@@ -378,10 +378,19 @@ static int gralloc_lock_ycbcr(gralloc_module_t const *module, buffer_handle_t ha
 			 * same as legacy HAL_PIXEL_FORMAT_YCbCr_420_SP used by DDK
 			 */
 			case HAL_PIXEL_FORMAT_YCbCr_420_888:
-				ystride = cstride = GRALLOC_ALIGN(hnd->width, 16);
 				ycbcr->y  = (void *)hnd->base;
-				ycbcr->cb = (void *)((unsigned char *)hnd->base + ystride * hnd->height);
-				ycbcr->cr = (void *)((unsigned char *)hnd->base + ystride * hnd->height + 1);
+				if (usage & GRALLOC_USAGE_PRIVATE_2)
+				{
+					ystride = cstride = GRALLOC_ALIGN(hnd->width, 256);
+					ycbcr->cb = (void *)((unsigned char *)hnd->base + ystride * hnd->aligned_height);
+					ycbcr->cr = (void *)((unsigned char *)hnd->base + ystride * hnd->aligned_height + 1);
+				}
+				else
+				{
+					ystride = cstride = GRALLOC_ALIGN(hnd->width, 16);
+					ycbcr->cb = (void *)((unsigned char *)hnd->base + ystride * hnd->height);
+					ycbcr->cr = (void *)((unsigned char *)hnd->base + ystride * hnd->height + 1);
+				}
 				ycbcr->ystride = ystride;
 				ycbcr->cstride = cstride;
 				ycbcr->chroma_step = 2;

--- a/common/gralloc/gralloc_priv.h
+++ b/common/gralloc/gralloc_priv.h
@@ -207,7 +207,11 @@ struct private_handle_t
 	int     fd; //Shallow copy, DO NOT duplicate
 	int     offset;
 
-	int	byte_stride;
+	int	byte_stride; // width-stride in bytes
+
+	// height with required alignment, used for VCU video buffers.
+	// Can be bigger than original requested height.
+	int	aligned_height;
 #if GRALLOC_ARM_DMA_BUF_MODULE
 	ion_user_handle_t ion_hnd;
 #endif

--- a/common/sepolicy/file_contexts
+++ b/common/sepolicy/file_contexts
@@ -1,2 +1,4 @@
 /dev/mali              u:object_r:gpu_device:s0
 /dev/dri/card0         u:object_r:gpu_device:s0
+/dev/allegroDecodeIP   u:object_r:video_device:s0
+/dev/allegroIP         u:object_r:video_device:s0

--- a/zcu106/zcu106_vcu/device-zcu106_vcu.mk
+++ b/zcu106/zcu106_vcu/device-zcu106_vcu.mk
@@ -72,7 +72,9 @@ PRODUCT_PACKAGES += \
 
 # Install required kernel modules
 KERNEL_MODULES += \
-    drivers/soc/xilinx/xlnx_vcu.ko
+    drivers/soc/xilinx/xlnx_vcu.ko \
+    drivers/soc/xilinx/xlnx_vcu_core.ko \
+    drivers/soc/xilinx/xlnx_vcu_clk.ko
 
 # Default OMX service to non-Treble
 PRODUCT_PROPERTY_OVERRIDES += \

--- a/zcu106/zcu106_vcu/init.zcu106_vcu.rc
+++ b/zcu106/zcu106_vcu/init.zcu106_vcu.rc
@@ -60,9 +60,9 @@ on post-fs
     setprop xlnx.v4l2.csi.dmsc_dts_name     a0250000.v_demosaic
     setprop xlnx.v4l2.csi.csiss_dts_name    a00f0000.csiss
     setprop xlnx.v4l2.csi.sensor_dts_name   IMX274
-    setprop xlnx.v4l2.hdmi.main_dts_name    vcap_hdmi_1
-    setprop xlnx.v4l2.hdmi.scaler_dts_name  a0080000.scaler
-    setprop xlnx.v4l2.hdmi.rx_dts_name      a0000000.hdmi_rx_ss
+    setprop xlnx.v4l2.hdmi.main_dts_name    vcap_hdmi
+    setprop xlnx.v4l2.hdmi.scaler_dts_name  a0080000.v_proc_ss
+    setprop xlnx.v4l2.hdmi.rx_dts_name      a0000000.v_hdmi_rx_ss
 
     # set properties for HDMI audio
     setprop xlnx.audio.card 1

--- a/zcu106/zcu106_vcu/init.zcu106_vcu.rc
+++ b/zcu106/zcu106_vcu/init.zcu106_vcu.rc
@@ -36,6 +36,8 @@ on post-fs
     setprop hwc.drm.device /dev/dri/card1
 
     # Initialize VCU
+    insmod /system/vendor/modules/xlnx_vcu_clk.ko
+    insmod /system/vendor/modules/xlnx_vcu_core.ko
     insmod /system/vendor/modules/xlnx_vcu.ko
     insmod /system/vendor/modules/allegro.ko
     insmod /system/vendor/modules/al5e.ko
@@ -43,7 +45,6 @@ on post-fs
 
     # Initialize HDMI
     insmod /system/vendor/modules/dp159.ko
-    insmod /system/vendor/modules/si5324.ko
     insmod /system/vendor/modules/xilinx-vphy.ko
     insmod /system/vendor/modules/xilinx-hdmi-tx.ko
     insmod /system/vendor/modules/xilinx-hdmi-rx.ko

--- a/zcu106/zcu106_vcu/init.zcu106_vcu.rc
+++ b/zcu106/zcu106_vcu/init.zcu106_vcu.rc
@@ -64,6 +64,11 @@ on post-fs
     setprop xlnx.v4l2.hdmi.scaler_dts_name  a0080000.scaler
     setprop xlnx.v4l2.hdmi.rx_dts_name      a0000000.hdmi_rx_ss
 
+    # set properties for HDMI audio
+    setprop xlnx.audio.card 1
+    setprop xlnx.audio.port 0
+    setprop xlnx.audio.use_24bit 1
+
     chown graphics graphics /sys/kernel/debug/sync/sw_sync
     chmod 777 /sys/kernel/debug/sync/sw_sync
 


### PR DESCRIPTION
Upgrade zcu106_vcu target to work with VCU HDMI Audio design BOOT.BIN from Xilinx VCU TRD 2018.3